### PR TITLE
fix: use nixpkgs-unstable (and not nixos-unstable) on macOS

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -123,7 +123,7 @@ jobs:
             pkgs+=(cachix)
           fi
           args=()
-          for pkg in ${pkgs[@]}; do args+=("github:nixos/nixpkgs/nixos-unstable#$pkg"); done
+          for pkg in ${pkgs[@]}; do args+=("github:nixos/nixpkgs/nixpkgs-unstable#$pkg"); done
           nix profile install ${args[@]}
 
       - name: clone nixpkgs


### PR DESCRIPTION
This syntax is gross, because GitHub Actions does not have a ternary operator or if-then-else.

But the idea is that if the OS is Linux, we use `nixos-unstable`, and if not, we use `nixpkgs-unstable`.

As of 23:30 UTC, 2025-06-22, it seems that `nix` does not build on macOS on the `nixos-unstable` channel. So the difference matters, at least on occasion.