### PR TITLE
feat: reclaim additional space

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -99,20 +99,61 @@ jobs:
       fetch_cmd_aarch64-darwin: ${{ steps.report.outputs.fetch_cmd_aarch64-darwin }}
 
     steps:
-      - name: prepare /nix
-        run: sudo mkdir /mnt/nix && sudo mount -m -o bind /mnt/nix /nix
-        if: ${{ matrix.system == 'x86_64-linux' || matrix.system == 'aarch64-linux' }}
+      - name: reclaim space (linux)
+        if: runner.os == 'Linux'
+        uses: wimpysworld/nothing-but-nix@main
+        with:
+          hatchet-protocol: rampage
+
+        # FIXME: takes ~9m on x86, but only ~2m on ARM
+        # TODO: figure out why
+        # - filesystem differences?
+        # - can we parallelize the `rm`? E.g. `find | parallel rm`
+      - name: reclaim space (darwin)
+        if: runner.os == 'macOS'
+        run: |
+          echo "::group::disk space (before)"
+          sudo df -h
+          echo "::endgroup::"
+
+          echo "::group::remove files"
+          sudo rm -rf \
+            /Applications/Xcode_* \
+            /Library/Developer/CoreSimulator \
+            /Library/Frameworks \
+            /Users/runner/.dotnet \
+            /Users/runner/.rustup \
+            /Users/runner/Library/Android \
+            /Users/runner/Library/Caches \
+            /Users/runner/Library/Developer/CoreSimulator \
+            /Users/runner/hostedtoolcache
+          echo "::endgroup::"
+
+          echo "::group::disable mds"
+          sudo mdutil -i off -a || echo "mdutil failed"
+          sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.metadata.mds.plist \
+           || echo "launchctl unload failed"
+          echo "::endgroup::"
+
+          echo "::group::disk space (after)"
+          sudo df -h
+          echo "::endgroup::"
 
       - name: install nix
         uses: cachix/install-nix-action@v31
         with:
+          # Putting build-dir in /nix is a workaround for https://github.com/wimpysworld/nothing-but-nix/issues/18
           extra_nix_config: |
+            build-dir = /nix/build
             sandbox = ${{
               (matrix.system == 'x86_64-darwin' && inputs.x86_64-darwin == 'yes_sandbox_false'
                 || matrix.system == 'aarch64-darwin' && inputs.aarch64-darwin == 'yes_sandbox_false') && 'false'
               || (matrix.system == 'x86_64-darwin' && inputs.x86_64-darwin == 'yes_sandbox_relaxed'
                 || matrix.system == 'aarch64-darwin' && inputs.aarch64-darwin == 'yes_sandbox_relaxed') && 'relaxed'
               || 'true' }}
+
+      - name: create build-dir
+        run: sudo mkdir -p /nix/build
 
       - name: install packages
         run: |


### PR DESCRIPTION
Use nothing-but-nix on linux and `rm -rf` on darwin.

---

The biggest issue I've found in testing is that removing files takes a long time on x86_64-darwin (sometimes nearly 10m). On aarch64-darwin it is relatively quick (usually 1-2m)

We may also want to go through the "included software" list and see if there is anything else worth removing on darwin:
- [aarch64-darwin](https://github.com/actions/runner-images/blob/macos-14-arm64/20250630.1634/images/macos/macos-14-arm64-Readme.md)
- [x86_64-darwin](https://github.com/actions/runner-images/blob/macos-13/20250630.1295/images/macos/macos-13-Readme.md)

However, the current implementation already seems fairly effective:
- x86_64-linux: 25G -> 129G
- aarch64-linux: 49G -> 49G (?)
- aarch64-darwin: 46Gi -> 238Gi
- x86_64-darwin: 178Gi -> 294Gi

---

Note: I also moved nix's `build-dir` into `/nix` to workaround https://github.com/wimpysworld/nothing-but-nix/issues/18

---

Based on and closes https://github.com/defelo/nixpkgs-review-gha/pull/9
