### PR TITLE
feat: don't be pedantic about sandbox setting when on linux

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -202,14 +202,18 @@ jobs:
 
       - name: generate report
         id: report
+        env:
+          OS: ${{ runner.os }}
         run: |
           if [[ -s fetch_cmd ]]; then
             cat fetch_cmd
             echo fetch_cmd_${{ matrix.system }}=$(base64 -w0 fetch_cmd) >> "$GITHUB_OUTPUT"
           fi
           dir=~/.cache/nixpkgs-review/pr-${PR_NUMBER}
-          sandbox=$(nix config show sandbox)
-          sed -i '/^###/s/$/ (sandbox = '"$sandbox"')/' $dir/report.md
+          if [ "$OS" != "Linux" ]; then
+            sandbox=$(nix config show sandbox)
+            sed -i '/^###/s/$/ (sandbox = '"$sandbox"')/' "$dir/report.md"
+          fi
           cat $dir/report.md
           report=$(jq -c '.+{$md}' $dir/report.json --rawfile md $dir/report.md | base64 -w0)
           echo report_${{ matrix.system }}=$report >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
I often see `nixpkgs-review-gha` reports [like this](https://github.com/NixOS/nixpkgs/pull/422189#issuecomment-3033579304). Here, the `x86_64-linux (sandbox = true)` is completely redundant. I removed it on my fork, but you might want this change as well.

(cherry-picked from 8274cbf710f7daefcc58851033e3ea22f93a0898)