### PR TITLE
feat: automatically merge on successful review

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -62,11 +62,15 @@ on:
         required: true
         type: boolean
         default: true
-      approve-on-success:
-        description: "Approve PR on review success"
+      on-success:
+        description: "What to do on review success"
         required: true
-        type: boolean
-        default: false
+        type: choice
+        default: nothing
+        options:
+          - nothing
+          - approve
+          - merge
 
 jobs:
   prepare:
@@ -75,6 +79,7 @@ jobs:
       pr: ${{ steps.pr.outputs.pr }}
       head: ${{ steps.pr.outputs.head }}
       merge: ${{ steps.pr.outputs.merge }}
+      author_id: ${{ steps.pr.outputs.author_id }}
 
     steps:
       - name: get pr
@@ -94,6 +99,7 @@ jobs:
           echo "pr=$pr" >> "$GITHUB_OUTPUT"
           echo "head=$(jq -r '.head.sha' <<< "$pr")" >> "$GITHUB_OUTPUT"
           echo "merge=$(jq -r '.merge_commit_sha' <<< "$pr")" >> "$GITHUB_OUTPUT"
+          echo "author_id=$(jq -r '.user.id' <<< "$pr")" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ github.token }}
 
@@ -190,7 +196,7 @@ jobs:
           if [[ ${{ vars.ATTIC_SERVER != '' && vars.ATTIC_CACHE != '' }} = true ]]; then
             attic login default "$ATTIC_SERVER" "$ATTIC_TOKEN"
             if ! attic cache info "$ATTIC_CACHE"; then
-              echo "::error:: attic returned an error"
+              echo "::error::attic returned an error"
               exit 0
             fi
             attic push --stdin "$ATTIC_CACHE" < paths
@@ -323,8 +329,8 @@ jobs:
 
   post-result:
     runs-on: ubuntu-latest
-    needs: [report]
-    if: ${{ inputs.post-result || inputs.approve-on-success }}
+    needs: [prepare, report]
+    if: ${{ inputs.post-result || inputs.on-success != 'nothing' }}
 
     steps:
       - name: fetch report
@@ -342,10 +348,42 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
       - name: approve pull request
-        if: ${{ inputs.approve-on-success && needs.report.outputs.success == 'true' }}
+        if: ${{ needs.report.outputs.success == 'true' && (inputs.on-success == 'approve' || inputs.on-success == 'merge') }}
         run: |
-          if [[ -n "$GH_TOKEN" ]]; then
-            gh pr -R NixOS/nixpkgs review ${PR_NUMBER} --approve -b "Approved automatically following the successful run of \`nixpkgs-review\`." || true
+          if [[ -z "$GH_TOKEN" ]]; then
+            echo "::error::Cannot approve the PR because no GH_TOKEN has been configured."
+            exit 1
+          fi
+          user_id="$(gh api /user --jq .id)"
+          if [[ "$user_id" != "$PR_AUTHOR_ID" ]]; then
+            gh pr -R NixOS/nixpkgs review ${PR_NUMBER} --approve -b "Approved automatically following the successful run of \`nixpkgs-review\`."
+          elif [[ "${{ inputs.on-success }}" = "approve" ]]; then
+            echo "::error::You cannot approve your own pull request."
+            exit 1
           fi
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          PR_AUTHOR_ID: ${{ needs.prepare.outputs.author_id }}
+
+      - name: merge pull request
+        if: ${{ needs.report.outputs.success == 'true' && inputs.on-success == 'merge' }}
+        run: |
+          if [[ -z "$GH_TOKEN" ]]; then
+            echo "::error::Cannot merge the PR because no GH_TOKEN has been configured."
+            exit 1
+          fi
+
+          is_committer="$(gh api /repos/NixOS/nixpkgs --jq .permissions.push)"
+          if [[ "$is_committer" = true ]]; then
+            gh pr -R NixOS/nixpkgs merge ${PR_NUMBER} --merge --match-head-commit "$HEAD"
+          else
+            current_head="$(gh api "/repos/NixOS/nixpkgs/pulls/$PR_NUMBER" --jq .head.sha)"
+            if [[ "$current_head" != "$HEAD" ]]; then
+              echo "::error::Refusing to merge because the head branch was modified (expected $HEAD, got $current_head instead)"
+              exit 1
+            fi
+            gh pr -R NixOS/nixpkgs comment ${PR_NUMBER} -b "@NixOS/nixpkgs-merge-bot merge"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          HEAD: ${{ needs.prepare.outputs.head }}

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Run [nixpkgs-review](https://github.com/Mic92/nixpkgs-review) in GitHub Actions
 - Automatically post results on the reviewed pull request
 - Optionally start an [Upterm](https://upterm.dev/) session after nixpkgs-review has finished to allow interactive testing/debugging via SSH
 - Push new packages to an [Attic](https://github.com/zhaofengli/attic) or [Cachix](https://www.cachix.org/) cache
-- Automatically approve pull requests on review success
+- After a successful review, automatically approve the PR or merge it (directly or via the [nixpkgs-merge-bot](https://github.com/NixOS/nixpkgs-merge-bot))
 - Add a "Run nixpkgs-review" shortcut to pull request pages in nixpkgs
 
 ## Setup
@@ -16,8 +16,8 @@ Run [nixpkgs-review](https://github.com/Mic92/nixpkgs-review) in GitHub Actions
 2. In your fork, go to the [Actions](../../actions) tab and enable GitHub Actions workflows.
 3. If you don't want to set up [automatic self-updates](#automatic-self-updates-optional), please disable the `self-update` workflow ([Actions / `self-update`](../../actions/workflows/self-update.yml) > `...` button (top right corner) > `Disable workflow`).
 
-### Post Results / Auto Approve (optional)
-If you want nixpkgs-review-gha to automatically post the results on the reviewed pull requests or automatically approve them, you need to generate a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens):
+### Post Results / Auto Approve/Merge (optional)
+If you want nixpkgs-review-gha to automatically post the results on the reviewed pull requests or automatically approve/merge them, you need to generate a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens):
 
 1. Go to <https://github.com/settings/tokens> and generate a new **classic** token with the `public_repo` scope.
 2. In your fork, go to "Settings" > "Secrets and variables" > "Actions" and [add a new repository secret](../../settings/secrets/actions/new) with the name `GH_TOKEN` and set its value to the personal access token you generated before.

--- a/shortcut.js
+++ b/shortcut.js
@@ -19,7 +19,7 @@ const reviewDefaults = ({ title, commits, labels, author, authoredByMe, hasLinux
     // "push-to-cache": true,
     // "upterm": false,
     // "post-result": true,
-    // "approve-on-success": false,
+    // "on-success": "nothing",
   };
 };
 


### PR DESCRIPTION
Ensures that the head commit matches the commit that has been reviewed before merging. Uses the merge bot if the user is not a committer.

---

Tests:
- [x] `on-success = nothing`
  - [x] `post-result = false` ([16455868555](https://github.com/Defelo/nixpkgs-review-gha/actions/runs/16455868555))
  - [x] `post-result = true` ([16455879638](https://github.com/Defelo/nixpkgs-review-gha/actions/runs/16455879638))
- [x] `on-success = approve`
  - [x] `user_id == author_id` ([16455890537](https://github.com/Defelo/nixpkgs-review-gha/actions/runs/16455890537))
  - [x] `user_id != author_id` ([16456167686](https://github.com/Defelo/nixpkgs-review-gha/actions/runs/16456167686))
- [x] `on-success = merge`
  - [x] PAT user is committer, head is up-to-date ([16456032609](https://github.com/Defelo/nixpkgs-review-gha/actions/runs/16456032609))
  - [x] PAT user is committer, head is outdated ([16483300359](https://github.com/Defelo/nixpkgs-review-gha/actions/runs/16483300359))
  - [x] PAT user is not a committer, head is up-to-date ([16500428077](https://github.com/Defelo/nixpkgs-review-gha/actions/runs/16500428077))
  - [x] PAT user is not a committer, head is outdated ([16500113809](https://github.com/Defelo/nixpkgs-review-gha/actions/runs/16500113809))