### PR TITLE
fix: use `nix profile add` instead of `install`

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -153,7 +153,7 @@ jobs:
           elif [[ ${{ inputs.push-to-cache && vars.CACHIX_CACHE != '' }} = true ]]; then
             pkgs+=(cachix)
           fi
-          nix profile install -f packages.nix ${pkgs[@]}
+          nix profile add -f packages.nix ${pkgs[@]}
 
       - name: clone nixpkgs
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR replaces the deprecated `nix profile install` with `nix profile add`, as per the suggestion when the CI action runs `nix profile install`:
```
warning: 'install' is a deprecated alias for 'add'
```