### PR TITLE
feat(review): support passing extra build-args

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -47,16 +47,20 @@ on:
         description: "nixpkgs-review extra args"
         required: false
         type: string
+      extra-build-args:
+        description: "nixpkgs-review build-args"
+        required: false
+        type: string
       push-to-cache:
         description: "Push to cache"
         required: true
         type: boolean
         default: true
-      upterm:
-        description: "Start upterm session after nixpkgs-review"
-        required: true
-        type: boolean
-        default: false
+      # upterm:
+      #   description: "Start upterm session after nixpkgs-review"
+      #   required: true
+      #   type: boolean
+      #   default: false
       post-result:
         description: "Post Result"
         required: true
@@ -177,7 +181,7 @@ jobs:
             --no-shell \
             --no-headers \
             --print-result \
-            --build-args="-L" \
+            --build-args="-L${EXTRA_BUILD_ARGS:+ $EXTRA_BUILD_ARGS}" \
             --pr-json="$PR_JSON" \
             $EXTRA_ARGS \
             || true
@@ -185,6 +189,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           EXTRA_ARGS: ${{ inputs.extra-args }}
+          EXTRA_BUILD_ARGS: ${{ inputs.extra-build-args }}
           PR_JSON: ${{ needs.prepare.outputs.pr }}
 
       - name: push results to cache
@@ -235,11 +240,11 @@ jobs:
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
           CACHIX_SIGNING_KEY: ${{ secrets.CACHIX_SIGNING_KEY }}
 
-      - name: start upterm session
-        if: ${{ inputs.upterm }}
-        uses: owenthereal/action-upterm@v1
-        with:
-          limit-access-to-actor: true
+      # - name: start upterm session
+      #   if: ${{ inputs.upterm }}
+      #   uses: owenthereal/action-upterm@v1
+      #   with:
+      #     limit-access-to-actor: true
 
       - name: generate report
         id: report


### PR DESCRIPTION
Many thanks for this fantastic project Defelo.

This PR is motivated by the need to pull from a cache during repeated execution with incremental inclusion of packages from the 100-500 package blast radius to get reasonable build times. It would probably be better paired with an issue targeted at that use case,

- #49

which doesn't strictly require the potential solution proposed here that introduces support for extra build-args. See https://github.com/NixOS/nixpkgs/pull/444225#issuecomment-3338920331 for context.

<details><summary>nixpkgs-review execution parameters</summary>
<p>

- [results](https://github.com/NixOS/nixpkgs/pull/444225#issuecomment-3338835832)

```sh
gh workflow run review.yml \
  --ref build-args \
  -f pr=444225 \
  -f x86_64-linux=true \
  -f aarch64-linux=true \
  -f x86_64-darwin=yes_sandbox_true \
  -f aarch64-darwin=yes_sandbox_true \
  -f extra-args="-p duckdb -p python312Packages.duckdb -p python313Packages.duckdb" \
  -f extra-build-args="--option extra-substituters https://cameronraysmith.cachix.org --option extra-trusted-public-keys cameronraysmith.cachix.org-1:aC8ZcRCVcQql77Qn//Q1jrKkiDGir+pIUjhUunN6aio=" \
  -f push-to-cache=true \
  -f post-result=true \
  -f on-success=nothing
```

</p>
</details>

I see there are at least two competing constraints on the review workflow:

- github limits workflow dispatch/call input arguments to 10
- the nixpkgs-review argument parsing is difficult to deal with such that overriding the build-args flag in `$EXTRA_ARGS` fails (at least in my experiments).

I don't think this PR yet contains the right solution, in part because I had to disable an input and temporarily chose the upterm boolean. In any case, I wanted to pass along this use case for your consideration.