### PR TITLE
Update URL format to new ocfox.me tracker

### DIFF
--- a/shortcut.user.js
+++ b/shortcut.user.js
@@ -29,7 +29,7 @@ const reviewDefaults = ({ title, commits, labels, author, authoredByMe, hasLinux
 
 const prTrackers = [
   { name: "nixpk.gs", toUrl: pr => `https://nixpk.gs/pr-tracker.html?pr=${pr}` },
-  { name: "ocfox.me", toUrl: pr => `https://nixpkgs-tracker.ocfox.me/?pr=${pr}` },
+  { name: "ocfox.me", toUrl: pr => `https://ocfox.me/nixpkgs-tracker?pr=${pr}` },
 ];
 
 const sleep = duration => new Promise(resolve => setTimeout(resolve, duration));


### PR DESCRIPTION
This pull request makes a minor update to the `prTrackers` array in `shortcut.user.js`, specifically updating the URL for the "ocfox.me" tracker to point to its new location.

* Updated the "ocfox.me" PR tracker URL in the `prTrackers` array to `https://ocfox.me/nixpkgs-tracker?pr=${pr}`.