### PR TITLE
chore: pin actions and add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+---
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      time: "11:00"
+      timezone: UTC
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: chore
+    groups:
+      gha:
+        patterns:
+          - "*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
       || (matrix.system == 'aarch64-darwin' && 'macos-latest') }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: .github/actions
 
@@ -99,6 +99,6 @@ jobs:
 
       - name: start upterm session
         if: ${{ inputs.upterm }}
-        uses: owenthereal/action-upterm@v1
+        uses: owenthereal/action-upterm@f26ebc11e22a09b8365f39d2cdafd06f63b42053 # v1
         with:
           limit-access-to-actor: true

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,7 +25,7 @@ jobs:
       || (matrix.system == 'aarch64-darwin' && 'macos-latest') }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: setup nix
         uses: ./.github/actions/setup-nix
         with:

--- a/.github/workflows/flake-update.yml
+++ b/.github/workflows/flake-update.yml
@@ -34,7 +34,7 @@ jobs:
           FLAKE_UPDATE_SSH_KEY: ${{ secrets.FLAKE_UPDATE_SSH_KEY }}
 
       - name: install nix
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@616559265b40713947b9c190a8ff4b507b5df49b # v31
 
       - name: configure git
         run: |
@@ -42,7 +42,7 @@ jobs:
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: clone repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ssh-key: ${{ secrets.FLAKE_UPDATE_SSH_KEY }}
 

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -130,7 +130,7 @@ jobs:
       || (matrix.system == 'aarch64-darwin' && 'macos-latest') }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             .github/actions
@@ -163,7 +163,7 @@ jobs:
           nix profile add "${pkgs[@]/#/.#}" --builders ''
 
       - name: clone nixpkgs
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           repository: NixOS/nixpkgs
           path: nixpkgs
@@ -237,7 +237,7 @@ jobs:
 
       - name: start upterm session
         if: ${{ inputs.upterm }}
-        uses: owenthereal/action-upterm@v1
+        uses: owenthereal/action-upterm@f26ebc11e22a09b8365f39d2cdafd06f63b42053 # v1
         with:
           limit-access-to-actor: true
 
@@ -264,7 +264,7 @@ jobs:
         env:
           OS: ${{ runner.os }}
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: report_${{ matrix.system }}.json
           path: report_${{ matrix.system }}.json
@@ -278,7 +278,7 @@ jobs:
       success: ${{ steps.report.outputs.success }}
 
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           merge-multiple: true
 
@@ -325,7 +325,7 @@ jobs:
           MERGE: ${{ needs.prepare.outputs.merge }}
           EXTRA_ARGS: ${{ inputs.extra-args }}
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: report.md
           path: report.md
@@ -338,7 +338,7 @@ jobs:
     if: ${{ inputs.post-result || inputs.on-success != 'nothing' }}
 
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: report.md
 

--- a/.github/workflows/self-update.yml
+++ b/.github/workflows/self-update.yml
@@ -38,7 +38,7 @@ jobs:
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: clone repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           token: ${{ secrets.GH_SELF_UPDATE_TOKEN }}
           fetch-depth: 0


### PR DESCRIPTION
- **chore: pin actions by digest**
- **chore: add dependabot config**

It's safer to pin actions by digest since branches can be force written over.

* https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions
* https://pin-gh-actions.kammel.dev/
* https://blog.rafaelgss.dev/why-you-should-pin-actions-by-commit-hash
* https://github.com/aquasecurity/trivy/security/advisories/GHSA-69fq-xp46-6x23
  * Recommended Actions > Pin GitHub Actions to Full SHA Hashes

This does mean that because branches aren't rewritten there are no implicit automatic updates now.

Adding dependabot means a PR will be automatically created weekly to bump the action versions explicitly.
I think dependabot should be disabled by default on forks (it is on mine but maybe it wont once the dependabot config is added)
but it can be disabled by going to Settings > Security and Quanity > Advanced Security > Dependabot.

Having it disabled means people can wait for updates to this repo and just sync.
Or they could choose to have dependabot propose updates and merge them early but then they'd need to resolve conflicts.
