### PR TITLE
feat: support riscv64-linux via RISE runners

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -24,7 +24,7 @@ runs:
   using: composite
   steps:
     - name: reclaim space (linux)
-      if: runner.os == 'Linux'
+      if: runner.os == 'Linux' && inputs.system != 'riscv64-linux'
       uses: wimpysworld/nothing-but-nix@main
       with:
         hatchet-protocol: rampage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,11 @@ on:
           - yes_sandbox_false
           - yes_sandbox_relaxed
           - yes_sandbox_true
+      riscv64-linux:
+        description: "Build on riscv64-linux (RISE runners)"
+        required: true
+        type: boolean
+        default: false
       upterm:
         description: "Start upterm session after nix build"
         required: true
@@ -56,16 +61,19 @@ jobs:
           - aarch64-linux
           - x86_64-darwin
           - aarch64-darwin
+          - riscv64-linux
         exclude:
           - system: ${{ !inputs.x86_64-linux && 'x86_64-linux' || '' }}
           - system: ${{ !inputs.aarch64-linux && 'aarch64-linux' || '' }}
           - system: ${{ inputs.x86_64-darwin == 'no' && 'x86_64-darwin' || '' }}
           - system: ${{ inputs.aarch64-darwin == 'no' && 'aarch64-darwin' || '' }}
+          - system: ${{ !inputs.riscv64-linux && 'riscv64-linux' || '' }}
     runs-on: >-
       ${{ (matrix.system == 'x86_64-linux' && 'ubuntu-latest')
       || (matrix.system == 'aarch64-linux' && 'ubuntu-24.04-arm')
       || (matrix.system == 'x86_64-darwin' && 'macos-latest')
-      || (matrix.system == 'aarch64-darwin' && 'macos-latest') }}
+      || (matrix.system == 'aarch64-darwin' && 'macos-latest')
+      || (matrix.system == 'riscv64-linux' && 'ubuntu-24.04-riscv') }}
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -43,6 +43,11 @@ on:
           - yes_sandbox_false
           - yes_sandbox_relaxed
           - yes_sandbox_true
+      riscv64-linux:
+        description: "Run on riscv64-linux (RISE runners)"
+        required: true
+        type: boolean
+        default: false
       extra-args:
         description: "nixpkgs-review extra args"
         required: false
@@ -118,16 +123,19 @@ jobs:
           - aarch64-linux
           - x86_64-darwin
           - aarch64-darwin
+          - riscv64-linux
         exclude:
           - system: ${{ !inputs.x86_64-linux && 'x86_64-linux' || '' }}
           - system: ${{ !inputs.aarch64-linux && 'aarch64-linux' || '' }}
           - system: ${{ inputs.x86_64-darwin == 'no' && 'x86_64-darwin' || '' }}
           - system: ${{ inputs.aarch64-darwin == 'no' && 'aarch64-darwin' || '' }}
+          - system: ${{ !inputs.riscv64-linux && 'riscv64-linux' || '' }}
     runs-on: >-
       ${{ (matrix.system == 'x86_64-linux' && 'ubuntu-latest')
       || (matrix.system == 'aarch64-linux' && 'ubuntu-24.04-arm')
       || (matrix.system == 'x86_64-darwin' && 'macos-latest')
-      || (matrix.system == 'aarch64-darwin' && 'macos-latest') }}
+      || (matrix.system == 'aarch64-darwin' && 'macos-latest')
+      || (matrix.system == 'riscv64-linux' && 'ubuntu-24.04-riscv') }}
 
     steps:
       - uses: actions/checkout@v6
@@ -285,7 +293,7 @@ jobs:
       - name: generate report
         id: report
         run: |
-          systems=(x86_64-linux aarch64-linux x86_64-darwin aarch64-darwin)
+          systems=(x86_64-linux aarch64-linux x86_64-darwin aarch64-darwin riscv64-linux)
 
           for system in "${systems[@]}"; do
             [[ -s "report_${system}.json" ]] || continue

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Run [nixpkgs-review](https://github.com/Mic92/nixpkgs-review) in GitHub Actions
 
 ## Features
 - Build on `x86_64-linux`, `aarch64-linux`, `x86_64-darwin` and `aarch64-darwin`
+- Optionally build on `riscv64-linux` via the [RISE RISC-V Runners](https://riseproject.dev/2026/03/24/announcing-the-rise-risc-v-runners-free-native-risc-v-ci-on-github/) (off by default; requires installing the RISE GitHub App on your fork)
 - No local setup
 - Automatically post results on the reviewed pull request
 - Optionally start an [Upterm](https://upterm.dev/) session after nixpkgs-review has finished to allow interactive testing/debugging via SSH
@@ -73,7 +74,7 @@ Set the following [secrets](../../settings/secrets/actions):
     -V +1h \
     $PUBKEY_PATH
   ```
-  
+
   </details>
 
 Set the following [variables](../../settings/variables/actions):

--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,7 @@
         "aarch64-linux"
         "x86_64-darwin"
         "aarch64-darwin"
+        "riscv64-linux"
       ];
     in
 

--- a/shortcut.user.js
+++ b/shortcut.user.js
@@ -19,6 +19,7 @@ const reviewDefaults = ({ title, commits, labels, author, authoredByMe, hasLinux
     "aarch64-linux": !hasRebuilds || hasLinuxRebuilds,
     "x86_64-darwin": !hasRebuilds || hasDarwinRebuilds ? `yes_sandbox_${darwinSandbox}` : "no",
     "aarch64-darwin": !hasRebuilds || hasDarwinRebuilds ? `yes_sandbox_${darwinSandbox}` : "no",
+    // "riscv64-linux": false,
     // "extra-args": "",
     // "push-to-cache": true,
     // "upterm": false,


### PR DESCRIPTION
Adds a `riscv64-linux` toggle to the `review` and `build` workflows, mapping to the `ubuntu-24.04-riscv` label from the [RISE RISC-V Runners](https://riseproject.dev/2026/03/24/announcing-the-rise-risc-v-runners-free-native-risc-v-ci-on-github/). Off by default.

Users opting in need to install the [RISE GitHub App](https://github.com/apps/rise-risc-v-runners-personal) (or the [organization variant](https://github.com/apps/rise-risc-v-runners)) on their fork.

`setup-nix` skips `wimpysworld/nothing-but-nix` on riscv64 (hat action only supports official Ubuntu x86_64/arm64 runners). The cachix Nix installer works as-is on riscv64.

Closes #120 