### PR TITLE
feat(userscript): set channel-specific `x86_64-darwin` default

### DIFF
--- a/shortcut.user.js
+++ b/shortcut.user.js
@@ -8,16 +8,27 @@ const user = document.querySelector("header.GlobalNav button[data-login]")?.getA
 
 const repo = user ? `${user}/nixpkgs-review-gha` : null;
 
-const reviewDefaults = ({ title, commits, labels, author, authoredByMe, hasLinuxRebuilds, hasDarwinRebuilds }) => {
+const reviewDefaults = ({
+  title,
+  commits,
+  labels,
+  author,
+  authoredByMe,
+  targetBranch,
+  hasLinuxRebuilds,
+  hasDarwinRebuilds,
+}) => {
   const darwinSandbox = "relaxed";
 
   const hasRebuilds = hasLinuxRebuilds || hasDarwinRebuilds;
+  const targetsStableRelease = targetBranch.match(/-\d\d\.\d\d$/);
 
   return {
     // "branch": "main",
     "x86_64-linux": !hasRebuilds || hasLinuxRebuilds,
     "aarch64-linux": !hasRebuilds || hasLinuxRebuilds,
-    "x86_64-darwin": !hasRebuilds || hasDarwinRebuilds ? `yes_sandbox_${darwinSandbox}` : "no",
+    "x86_64-darwin":
+      targetsStableRelease && (!hasRebuilds || hasDarwinRebuilds) ? `yes_sandbox_${darwinSandbox}` : "no",
     "aarch64-darwin": !hasRebuilds || hasDarwinRebuilds ? `yes_sandbox_${darwinSandbox}` : "no",
     // "riscv64-linux": false,
     // "extra-args": "",
@@ -47,6 +58,9 @@ const getPrDetails = pr => {
   const title = document.querySelector(
     "div[data-component=TitleArea] .text-normal.markdown-title, bdi.js-issue-title.markdown-title",
   ).innerText;
+  const targetBranch = document
+    .querySelector("[data-component=PH_Title] a[data-component=BranchName]")
+    .innerText.replace(/^NixOS:/, "");
   const commits = [...document.querySelectorAll(".TimelineItem-body a.markdown-title[href*='/commits/']")].flatMap(
     ({ title, href }) => {
       const match = /\/NixOS\/nixpkgs\/pull\/(\d+)\/commits\/([0-9a-f]+)$/i.exec(href);
@@ -71,7 +85,17 @@ const getPrDetails = pr => {
     .innerText.trim()
     .toUpperCase();
 
-  return { title, commits, labels, author, authoredByMe, hasLinuxRebuilds, hasDarwinRebuilds, state };
+  return {
+    title,
+    commits,
+    labels,
+    author,
+    authoredByMe,
+    targetBranch,
+    hasLinuxRebuilds,
+    hasDarwinRebuilds,
+    state,
+  };
 };
 
 const setupActionsPage = async () => {


### PR DESCRIPTION
When targeting unstable (currently 26.11), `x86_64-darwin` is unsupported. See #113.

In that scenario, the userscript can disable `x86_64-darwin` builds by default.

We can detect the targeted branch by reading `[data-component=BranchName]` and ~~comparing against a set of known unstable-channel dev branches~~ checking if it matches the "release branch" pattern `-\d\d\.\d\d$`.

This does not need to be completely perfect, as it only provides a default. It can also be removed in ~9 months when `x86_64-darwin` will not be supported by any supported Nixpkgs release.

I've tested this script locally against:
- [x] A PR targeting `master`
- [x] A PR targeting `release-26.05`
- [x] A PR targeting `release-25.11`