### PR TITLE
add extra-build-args

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,5 +1,5 @@
 name: review
-run-name: "review #${{ inputs.pr }}${{ inputs.extra-args && format(' ({0})', inputs.extra-args) || '' }}"
+run-name: "review #${{ inputs.pr }}${{ inputs.extra-args && format(' ({0})', inputs.extra-args) || '' }}${{ inputs.extra-build-args && format(' [{0}]', inputs.extra-build-args) || '' }}"
 
 permissions: {}
 
@@ -50,6 +50,10 @@ on:
         default: false
       extra-args:
         description: "nixpkgs-review extra args"
+        required: false
+        type: string
+      extra-build-args:
+        description: "nixpkgs-review extra build args"
         required: false
         type: string
       push-to-cache:
@@ -177,7 +181,7 @@ jobs:
           path: nixpkgs
           persist-credentials: false
 
-      - name: run nixpkgs-review ${{ inputs.extra-args }}
+      - name: run nixpkgs-review ${{ inputs.extra-args }} ${{ inputs.extra-build-args }}
         run: |
           nixpkgs-review -- \
             pr ${PR_NUMBER} \
@@ -185,13 +189,14 @@ jobs:
             --no-exit-status \
             --no-headers \
             --print-result \
-            --build-args="-L $JOBS_ARG" \
+            --build-args="-L $JOBS_ARG $EXTRA_BUILD_ARGS" \
             --pr-json="$PR_JSON" \
             $EXTRA_ARGS
         working-directory: nixpkgs
         env:
           GITHUB_TOKEN: ${{ github.token }}
           EXTRA_ARGS: ${{ inputs.extra-args }}
+          EXTRA_BUILD_ARGS: ${{ inputs.extra-build-args }}
           PR_JSON: ${{ needs.prepare.outputs.pr }}
           JOBS_ARG: ${{ vars.USE_BUILDERS == 'always' && '-j0' || '' }}
 
@@ -332,6 +337,7 @@ jobs:
           HEAD: ${{ needs.prepare.outputs.head }}
           MERGE: ${{ needs.prepare.outputs.merge }}
           EXTRA_ARGS: ${{ inputs.extra-args }}
+          EXTRA_BUILD_ARGS: ${{ inputs.extra-build-args }}
 
       - uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
Hi,

Some of my builds are too big and just kill the runners (eg. `Error: Process completed with exit code 143.` in https://github.com/nim65s/nixpkgs-review-gha/actions/runs/27040982825/job/79816684081), so I 
I need to pass extra `--build-args` things to reduce resource use, like `-j 1` and/or `--cores 2`.

Here is a quick fix where `-j 1 --cores 2` did fix that current use case: https://github.com/nim65s/nixpkgs-review-gha/actions/runs/27058703232/job/79867656756