### PR TITLE
feat(workflows): actionlint

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -1,23 +1,18 @@
 name: setup-nix
+description: Set up Nix with optional remote builder support.
 
 inputs:
   system:
-    type: string
     required: true
   sandbox:
-    type: string
     default: "true"
   extra-nix-config:
-    type: string
     default: ""
   builders:
-    type: string
     default: ""
   ssh-key:
-    type: string
     default: ""
   ssh-cert:
-    type: string
     default: ""
 
 runs:

--- a/.github/actions/setup-nu/action.yml
+++ b/.github/actions/setup-nu/action.yml
@@ -1,4 +1,5 @@
 name: setup-nu
+description: Download and install Nushell for the current runner platform.
 
 runs:
   using: composite

--- a/flake.nix
+++ b/flake.nix
@@ -70,6 +70,20 @@
           ${lib.getExe pkgs.nushell} -c 'for x in (glob ${self}/**/*.nu) { print $"checking ($x)"; nu-check $x -d }'
           touch $out
         '';
+        actionlint =
+          pkgs.runCommand "actionlint"
+            {
+              nativeBuildInputs = [
+                pkgs.actionlint
+                pkgs.shellcheck
+              ];
+            }
+            ''
+              cp -r --no-preserve=mode ${self} src
+              cd src
+              actionlint
+              touch $out
+            '';
       });
     };
 


### PR DESCRIPTION
## Summary

Introduce [actionlint](https://github.com/rhysd/actionlint) as a Nix flake check to statically lint all GitHub
Actions workflow files on every `nix flake check` run.

Fix https://github.com/Defelo/nixpkgs-review-gha/issues/40.

## Changes

### `flake.nix`

Add an `actionlint` check using `pkgs.actionlint` and `pkgs.shellcheck`.
The check copies the flake source into the Nix build sandbox and runs
`actionlint` from the repository root, which auto-discovers all files
under `.github/workflows/`. shellcheck is included so actionlint can
also lint the embedded shell scripts.

### `.github/actions/setup-nix/action.yml`

- Add the required top-level `description` field.
- Remove `type: string` from all inputs; the `type` key is only valid
for `workflow_dispatch` inputs, not composite action inputs.

### `.github/actions/setup-nu/action.yml`

- Add the required top-level `description` field.

## Test Plan

- [ ] Run `nix flake check --print-build-logs` locally to ensure `actionlint` check passes.
- [ ] Confirm CI passes on `check.yml` across all matrix systems.