### PR TITLE
review: enable `IDENTIFY_UNSUPPORTED_PACKAGES` feature by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,4 +125,4 @@ If a package fails to build, try to detect whether the build failure was caused 
 For example, most hosted GitHub Actions runners cannot build QEMU/KVM based NixOS tests because they lack the `kvm` feature.
 Trying to build a NixOS test on such a runner will always fail, so with this experimental feature enabled, packages that fail to build due to a missing system feature will be marked as "unsupported" and will NOT count towards review success/failure, i.e. if some packages are unsupported and all other packages have been built successfully, the PR *is* approved/merged automatically if you told nixpkgs-review-gha to do that.
 
-To enable this feature [create a new variable](../../settings/variables/actions/new) with the name `IDENTIFY_UNSUPPORTED_PACKAGES` and set its value to `1`.
+This feature is enabled by default. To disable it [create a new variable](../../settings/variables/actions/new) with the name `IDENTIFY_UNSUPPORTED_PACKAGES` and set its value to `0`.

--- a/review/review.nu
+++ b/review/review.nu
@@ -117,7 +117,7 @@ open $reportJson
 | get result
 | let result
 
-if $env.IDENTIFY_UNSUPPORTED_PACKAGES == '1' {
+if $env.IDENTIFY_UNSUPPORTED_PACKAGES != '0' {
   gha group "identify unsupported packages" {
     cd nixpkgs
     if ($result.failed | is-empty) { return $result }


### PR DESCRIPTION
I've been using this feature for almost a year now (see #37 for the initial implementation), so let's finally enable this by default. We can remove the flag later, so for now it's still possible to disable the feature again.